### PR TITLE
update venue by refs/heads/scrape-magnet

### DIFF
--- a/venues/magnet/scraped.ltsv
+++ b/venues/magnet/scraped.ltsv
@@ -25,6 +25,7 @@ name:ドリームカプセル	altName:	bldg:	level:5	phone:	url:https://magnetby
 name:バトロコsatellite渋谷駅前	altName:	bldg:	level:5	phone:0364551528	url:https://magnetbyshibuya109.jp/shop/batoroko-mini/
 name:マンガ展 渋谷-さち	altName:	bldg:	level:5	phone:	url:https://magnetbyshibuya109.jp/shop/%e3%83%9e%e3%83%b3%e3%82%ac%e5%b1%95%e3%80%80%e6%b8%8b%e8%b0%b7/
 name:マンガ展 渋谷-ふく	altName:	bldg:	level:5	phone:	url:https://magnetbyshibuya109.jp/shop/%e3%83%9e%e3%83%b3%e3%82%ac%e5%b1%95-%e6%b8%8b%e8%b0%b7-%e3%81%b5%e3%81%8f/
+name:Happi.Tokyo POPUP STORE	altName:	bldg:	level:6	phone:0368216444	url:https://magnetbyshibuya109.jp/shop/happi-tokyo-popup-store/
 name:ONE PIECE 麦わらストア	altName:	bldg:	level:6	phone:0364169222	url:https://magnetbyshibuya109.jp/shop/%e9%ba%a6%e3%82%8f%e3%82%89%e3%82%b9%e3%83%88%e3%82%a2/
 name:RECOfan	altName:	bldg:	level:6	phone:0367127977	url:https://magnetbyshibuya109.jp/shop/recofan/
 name:SHIBUYA SCRAMBLE S	altName:	bldg:	level:7	phone:0345000409	url:https://magnetbyshibuya109.jp/shop/shibuya-scramble-s/


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a new venue listing in the Shibuya area: Happi.Tokyo POPUP STORE (level 6, MAGNET by SHIBUYA109). The entry includes phone contact (03-6821-6444) and official URL for details and hours. No existing listings were changed; this additive update expands venue coverage for users browsing Shibuya locations today.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->