### PR TITLE
update venue by refs/heads/scrape-de-aone

### DIFF
--- a/venues/de-aone/scraped.ltsv
+++ b/venues/de-aone/scraped.ltsv
@@ -10,10 +10,8 @@ name:TSUBAKIYA Jiyugaoka	altName:ツバキヤ ジユウガオカ	bldg:	level:1	p
 name:WINESHOP・ENOTECA	altName:ワインショップエノテカ	bldg:	level:1	phone:0364211194	url:
 name:WithGreen	altName:ウィズグリーン	bldg:	level:1	phone:0357268315	url:
 name:カメラのキタムラ	altName:カメラノキタムラ	bldg:	level:1	phone:0364595568	url:
-name:一果房	altName:イチカボウ	bldg:	level:1	phone:0357268855	url:
 name:LOGEMENT DE CLAIRE	altName:ロジュモン ド クレール	bldg:	level:2	phone:0357268398	url:
 name:MONEYDOCTOR PREMIER	altName:マネードクタープレミア	bldg:	level:2	phone:0364213967	url:
-name:Natural Shoe Store	altName:ナチュラルシューストア	bldg:	level:2	phone:0364211560	url:
 name:RISTRETTO & CROISSANT LABORATORIO	altName:リストレット アンド クロワッサン ラボラトリオ	bldg:	level:2	phone:0357269033	url:
 name:Three little song birds	altName:スリーリトルソングバーズ	bldg:	level:2	phone:09026640023	url:
 name:YANUK	altName:ヤヌーク	bldg:	level:2	phone:0364595581	url:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated venue dataset by removing two entries from the DE Aone list: 一果房 (イチカボウ) and Natural Shoe Store (ナチュラルシューストア).
  * Users will no longer see these venues in listings, search, or maps.
  * No new venues were added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->