### PR TITLE
update venue by refs/heads/scrape-scramble-square

### DIFF
--- a/venues/scramble-square/scraped.ltsv
+++ b/venues/scramble-square/scraped.ltsv
@@ -139,6 +139,7 @@ name:OSAJI	altName:オサジ	bldg:	level:6	phone:0368050008	url:https://www.shib
 name:PAUL & JOE BEAUTE	altName:ポール アンド ジョー ボーテ	bldg:	level:6	phone:0368038603	url:https://www.shibuya-scramble-square.com/shops_restaurants/detail.html?shop_id=238
 name:POLA	altName:ポーラ	bldg:	level:6	phone:0364271837	url:https://www.shibuya-scramble-square.com/shops_restaurants/detail.html?shop_id=606
 name:RMK	altName:アールエムケー	bldg:	level:6	phone:08033905390	url:https://www.shibuya-scramble-square.com/shops_restaurants/detail.html?shop_id=256
+name:ROAliv	altName:ロアリブ	bldg:	level:6	phone:0368050135	url:https://www.shibuya-scramble-square.com/shops_restaurants/detail.html?shop_id=626
 name:ReFa	altName:リファ	bldg:	level:6	phone:0364526207	url:https://www.shibuya-scramble-square.com/shops_restaurants/detail.html?shop_id=250
 name:SHIRO	altName:シロ	bldg:	level:6	phone:0368038246	url:https://www.shibuya-scramble-square.com/shops_restaurants/detail.html?shop_id=249
 name:SHISEIDO	altName:シセイドウ	bldg:	level:6	phone:0368038610	url:https://www.shibuya-scramble-square.com/shops_restaurants/detail.html?shop_id=268


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded Shibuya Scramble Square listings with three new shops:
    * ROAliv (6F) with contact number and official URL.
    * +Q GOODS by Tokyu Department Store (5F) with contact number and official URL.
    * +Q BEAUTY by Tokyu Department Store (6F) with contact number and official URL.
  * Users can now discover, view details, and contact these stores via the app’s directory and search.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->