### PR TITLE
update venue by refs/heads/scrape-markcity

### DIFF
--- a/venues/markcity/scraped.ltsv
+++ b/venues/markcity/scraped.ltsv
@@ -141,7 +141,6 @@ name:東京 渋谷 かげん鮨	altName:	bldg:東急フードショー しぶち
 name:柿安ダイニング	altName:	bldg:東急フードショー しぶちか	level:-1	phone:0334774262	url:https://www.tokyu-dept.co.jp/shibuya_foodshow/shop/detail.html?shopcode=kakiyasudining
 name:桂林	altName:	bldg:東急フードショー しぶちか	level:-1	phone:0334774616	url:https://www.tokyu-dept.co.jp/shibuya_foodshow/shop/detail.html?shopcode=keirin
 name:浅草今半	altName:佃煮	bldg:東急フードショー しぶちか	level:-1	phone:0334774874	url:https://www.tokyu-dept.co.jp/shibuya_foodshow/shop/detail.html?shopcode=asakusaimahan_tsukudani
-name:海老屋總本舗	altName:	bldg:東急フードショー しぶちか	level:-1	phone:0334774872	url:https://www.tokyu-dept.co.jp/shibuya_foodshow/shop/detail.html?shopcode=ebiyasouhonpo
 name:深川太郎	altName:	bldg:東急フードショー しぶちか	level:-1	phone:0334774830	url:https://www.tokyu-dept.co.jp/shibuya_foodshow/shop/detail.html?shopcode=fukagawataro
 name:相模屋	altName:	bldg:東急フードショー しぶちか	level:-1	phone:0334774831	url:https://www.tokyu-dept.co.jp/shibuya_foodshow/shop/detail.html?shopcode=sagamiya
 name:蔭山樓	altName:	bldg:東急フードショー しぶちか	level:-1	phone:0334774342	url:https://www.tokyu-dept.co.jp/shibuya_foodshow/shop/detail.html?shopcode=kageyamarou


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Refreshed venue data: removed an outdated listing for 海老屋總本舗 within 東急フードショー しぶちか. Users will no longer see this shop in results or details, and associated contact/URL information has been cleared. No new venues were added in this update. This reduces the total venues count by one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->