### PR TITLE
update venue by refs/heads/scrape-shibuya-stream

### DIFF
--- a/venues/shibuya-stream/scraped.ltsv
+++ b/venues/shibuya-stream/scraped.ltsv
@@ -23,8 +23,6 @@ name:XIRINGUITO Escribà	altName:	bldg:	level:3	phone:0354686300	url:https://shi
 name:なかめのてっぺん	altName:	bldg:	level:3	phone:0364341508	url:https://shibuyastream.jp/shop/detail/?scd=000071
 name:クラフトビールタップ グリル＆キッチン	altName:	bldg:	level:3	phone:0364275768	url:https://shibuyastream.jp/shop/detail/?scd=000072
 name:スターバックス コーヒー	altName:	bldg:	level:3	phone:0364341384	url:https://shibuyastream.jp/shop/detail/?scd=000050
-name:串𠅘	altName:	bldg:	level:3	phone:0364276694	url:https://shibuyastream.jp/shop/detail/?scd=000080
 name:圓 弁柄	altName:	bldg:	level:3	phone:0364277700	url:https://shibuyastream.jp/shop/detail/?scd=000065
 name:大連餃子基地 DALIAN	altName:	bldg:	level:3	phone:0368050670	url:https://shibuyastream.jp/shop/detail/?scd=000068
 name:Bar & Dining「TORRENT」	altName:	bldg:	level:4	phone:0364271358	url:https://shibuyastream.jp/shop/detail/?scd=000073
-name:TORQUE SPICE ＆ HERB, TABLE ＆ COURT	altName:	bldg:	level:4	phone:0364511374	url:https://shibuyastream.jp/shop/detail/?scd=000074

--- a/venues/shibuya-stream/scraped.ltsv
+++ b/venues/shibuya-stream/scraped.ltsv
@@ -16,10 +16,10 @@ name:恵比寿 土鍋炊ごはん なかよし	altName:	bldg:	level:2	phone:	url
 name:酢重 Indigo	altName:	bldg:	level:2	phone:0334008850	url:https://shibuyastream.jp/shop/detail/?scd=000051
 name:金のおにぎりと天白のかつお出汁 かつおとぼんた	altName:	bldg:	level:2	phone:0368050218	url:https://shibuyastream.jp/shop/detail/?scd=000054
 name:鶏料理 清水	altName:	bldg:	level:2	phone:0364273710	url:https://shibuyastream.jp/shop/detail/?scd=000059
+name:Pizza＆Italian Leo	altName:	bldg:	level:3	phone:0364341558	url:https://shibuyastream.jp/shop/detail/?scd=000070
 name:SUSHI TOKYO TEN、	altName:	bldg:	level:3	phone:0364275076	url:https://shibuyastream.jp/shop/detail/?scd=000067
 name:TEPPAN KITCHEN	altName:	bldg:	level:3	phone:0364511016	url:https://shibuyastream.jp/shop/detail/?scd=000069
 name:XIRINGUITO Escribà	altName:	bldg:	level:3	phone:0354686300	url:https://shibuyastream.jp/shop/detail/?scd=000081
-name:【7/17OPEN】Pizza＆Italian Leo	altName:	bldg:	level:3	phone:0364341558	url:https://shibuyastream.jp/shop/detail/?scd=000070
 name:なかめのてっぺん	altName:	bldg:	level:3	phone:0364341508	url:https://shibuyastream.jp/shop/detail/?scd=000071
 name:クラフトビールタップ グリル＆キッチン	altName:	bldg:	level:3	phone:0364275768	url:https://shibuyastream.jp/shop/detail/?scd=000072
 name:スターバックス コーヒー	altName:	bldg:	level:3	phone:0364341384	url:https://shibuyastream.jp/shop/detail/?scd=000050


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the listing and display name for Pizza＆Italian Leo in the Shibuya Stream venue directory.
  * Updated the venue ordering for improved directory accuracy.
  * Removed outdated listings for 串𠅘 and TORQUE SPICE ＆ HERB, TABLE ＆ COURT.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->